### PR TITLE
Fixes missing tests in docs UI when cols are upcased

### DIFF
--- a/src/app/services/project_service.js
+++ b/src/app/services/project_service.js
@@ -187,7 +187,9 @@ angular
                 if (depends_on.length) {
                     var model = depends_on[0];
                     var node = project.nodes[model];
-                    var column = node.columns[test.column_name];
+                    var column = _.find(node.columns, function(col, col_name) {
+                        return col_name.toLowerCase() == test.column_name.toLowerCase();
+                    });
 
                     if (!column) {
                         return;


### PR DESCRIPTION
Fixes https://github.com/fishtown-analytics/dbt/issues/975

On Snowflake, unquoted column names are upcased. This PR does a case-insensitive match between columns in schema.yml and the catalog to represent tests in the merged project datastructure