### PR TITLE
add tags to docs view, dag view filters

### DIFF
--- a/src/app/components/graph/graph-launcher.html
+++ b/src/app/components/graph/graph-launcher.html
@@ -126,31 +126,31 @@
                                     </div>
                                 </label>
                                 <label class="field">
-                                    <div class="dropup" data-form-type="node_types">
+                                    <div class="dropup" data-form-type="tags">
                                         <select
                                             data-toggle="dropdown"
                                             class='field-input form-control input-dark'
-                                            ng-click="onSelectClick('node_types')"
-                                            ng-blur="onSelectBlur('node_types', $event)">
+                                            ng-click="onSelectClick('tags')"
+                                            ng-blur="onSelectBlur('tags', $event)">
                                             <option selected disabled hidden>
-                                                <span>{{ selectionLabel('node_types') }}</span>
+                                                <span>{{ selectionLabel('tags') }}</span>
                                             </option>
                                         </select>
                                         <ul
                                             class="dropdown-menu"
-                                            ng-show="isVisible('node_types')"
+                                            ng-show="isVisible('tags')"
                                             style="display: block">
                                             <li
                                                 class='text-dark'
-                                                ng-repeat="item in selectorService.options.node_types"
-                                                ng-click="onItemSelect('node_types', item, $event)">
+                                                ng-repeat="item in selectorService.options.tags"
+                                                ng-click="onItemSelect('tags', item, $event)">
                                                 {{ item }}
-                                                <span ng-show="isSelected('node_types', item)">
+                                                <span ng-show="isSelected('tags', item)">
                                                     <svg class="checked" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.285 2l-11.285 11.567-5.286-5.011-3.714 3.716 9 8.728 15-15.285z"/></svg>
                                                 </span>
                                             </li>
                                         </ul>
-                                        <div class="field-label">node types</div>
+                                        <div class="field-label">tags</div>
                                     </div>
                                 </label>
                                 <label class="field" style="flex: 4 0 160px">

--- a/src/app/components/graph/graph-launcher.html
+++ b/src/app/components/graph/graph-launcher.html
@@ -133,7 +133,7 @@
                                             ng-click="onSelectClick('tags')"
                                             ng-blur="onSelectBlur('tags', $event)">
                                             <option selected disabled hidden>
-                                                <span>{{ selectionLabel('tags') }}</span>
+                                                <span>{{ selectionLabel('tags', 'untagged') }}</span>
                                             </option>
                                         </select>
                                         <ul
@@ -144,7 +144,8 @@
                                                 class='text-dark'
                                                 ng-repeat="item in selectorService.options.tags"
                                                 ng-click="onItemSelect('tags', item, $event)">
-                                                {{ item }}
+                                                <span ng-if='item == null'>untagged</span>
+                                                <span ng-if='item != null'>{{ item }}</span>
                                                 <span ng-show="isSelected('tags', item)">
                                                     <svg class="checked" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.285 2l-11.285 11.567-5.286-5.011-3.714 3.716 9 8.728 15-15.285z"/></svg>
                                                 </span>

--- a/src/app/components/graph/graph-launcher.js
+++ b/src/app/components/graph/graph-launcher.js
@@ -99,14 +99,14 @@ angular
                 }
             }
 
-            scope.selectionLabel = function(form) {
+            scope.selectionLabel = function(form, fallback_string) {
                 var model = selectorService.selection.dirty[form];
                 var all = selectorService.options[form];
 
                 if (model.length == 0) {
                     return "None selected";
                 } else if (model.length == 1) {
-                    return model[0];
+                    return model[0] || fallback_string;
                 } else if (model.length == all.length) {
                     return "All selected";
                 } else {

--- a/src/app/components/graph/graph-launcher.js
+++ b/src/app/components/graph/graph-launcher.js
@@ -22,7 +22,7 @@ angular
             scope.selectorService = selectorService;
 
             var forms = {
-                node_types: {
+                tags: {
                     visible: false,
                 },
                 packages: {
@@ -35,7 +35,7 @@ angular
 
                 var closest_dropup = $(e.target).closest(".dropup");
                 if (!closest_dropup.length) {
-                    forms.node_types.visible = false;
+                    forms.tags.visible = false;
                     forms.packages.visible = false;
                 }
 

--- a/src/app/components/table_details/table_details.html
+++ b/src/app/components/table_details/table_details.html
@@ -13,7 +13,9 @@
                         <div class="detail-body">
                             <dl class='detail'>
                                 <dt class="detail-label">Tags</dt>
-                                <dd ng-if="model.tags.length > 0" class="detail-value">{{ model.tags.join(", ") }}</dd>
+                                <dd ng-if="model.tags.length > 0" class="detail-value">
+                                    <span ng-repeat="tag in model.tags"><code>{{ tag }}</code>&nbsp;</span>
+                                </dd>
                                 <dd ng-if="model.tags.length == 0" class="detail-value">untagged</dd>
                             </dl>
                             <dl class="detail"

--- a/src/app/components/table_details/table_details.html
+++ b/src/app/components/table_details/table_details.html
@@ -11,9 +11,10 @@
                         </div>
                         -->
                         <div class="detail-body">
-                            <dl class="detail">
-                                <dt class='detail-label'>Details</dt>
-                                <dd class='detail-value'></dd>
+                            <dl class='detail'>
+                                <dt class="detail-label">Tags</dt>
+                                <dd ng-if="model.tags.length > 0" class="detail-value">{{ model.tags.join(", ") }}</dd>
+                                <dd ng-if="model.tags.length == 0" class="detail-value">None</dd>
                             </dl>
                             <dl class="detail"
                                 ng-repeat="item in details">
@@ -36,10 +37,6 @@
                         </div>
                         -->
                         <div class="detail-body">
-                            <dl class="detail">
-                                <dt class='detail-label'>Table</dt>
-                                <dd class='detail-value'></dd>
-                            </dl>
                             <dl class="detail"
                                 ng-repeat="item in extended"
                                 ng-if="item.include">

--- a/src/app/components/table_details/table_details.html
+++ b/src/app/components/table_details/table_details.html
@@ -14,7 +14,7 @@
                             <dl class='detail'>
                                 <dt class="detail-label">Tags</dt>
                                 <dd ng-if="model.tags.length > 0" class="detail-value">{{ model.tags.join(", ") }}</dd>
-                                <dd ng-if="model.tags.length == 0" class="detail-value">None</dd>
+                                <dd ng-if="model.tags.length == 0" class="detail-value">untagged</dd>
                             </dl>
                             <dl class="detail"
                                 ng-repeat="item in details">

--- a/src/app/main/index.js
+++ b/src/app/main/index.js
@@ -149,7 +149,7 @@ angular
         $scope.search.results = projectService.search('');
 
         var packages = _.unique(_.pluck(_.values(project.nodes), 'package_name'))
-        var all_tags = [];
+        var all_tags = [null];
         _.each(project.nodes, function(node) {
             if (node.resource_type == 'model') {
                 var tags = node.tags;

--- a/src/app/main/index.js
+++ b/src/app/main/index.js
@@ -149,8 +149,15 @@ angular
         $scope.search.results = projectService.search('');
 
         var packages = _.unique(_.pluck(_.values(project.nodes), 'package_name'))
+        var all_tags = [];
+        _.each(project.nodes, function(node) {
+            if (node.resource_type == 'model') {
+                var tags = node.tags;
+                all_tags = _.union(all_tags, tags);
+            };
+        });
 
-        selectorService.init({packages: packages})
+        selectorService.init({packages: packages, tags: all_tags})
         setSelectedModel($state.params.unique_id);
 
         var cur_state = locationService.parseState($state.params);

--- a/src/app/services/node_selection_service.js
+++ b/src/app/services/node_selection_service.js
@@ -18,7 +18,7 @@ angular
         include: '',
         exclude: '',
         packages: [],
-        tags: [],
+        tags: [null],
         depth: 1,
     };
 
@@ -32,23 +32,18 @@ angular
 
         options: {
             packages: [],
-            tags: [],
+            tags: [null],
         }
     };
 
     service.init = function(defaults) {
-        var all_packages = defaults.packages;
-        var all_tags = defaults.tags;
+        _.each(defaults, function(value, attr) {
+            service.options[attr] = value;
+            initial_selector[attr] = value;
+            service.selection.clean[attr] = value;
+            service.selection.dirty[attr] = value;
+        });
 
-        service.options.packages = all_packages;
-        initial_selector.packages = all_packages;
-        service.selection.clean.packages = all_packages;
-        service.selection.dirty.packages = all_packages;
-
-        service.options.tags = all_tags;
-        initial_selector.tags = all_tags;
-        service.selection.clean.tags = all_tags;
-        service.selection.dirty.tags = all_tags;
     }
 
     service.resetSelection = function(node) {
@@ -334,8 +329,9 @@ angular
 
             var matched_package = _.includes(selected_spec.packages, node.data.package_name);
             var matched_tags = _.intersection(selected_spec.tags, node.data.tags).length > 0;
+            var matched_untagged = _.includes(selected_spec.tags, null) && (node.data.tags.length == 0);
 
-            if (!matched_package || !matched_tags) {
+            if (!matched_package || (!matched_tags && !matched_untagged)) {
                 nodes_to_prune.push(node.data.unique_id);
             }
         })

--- a/src/app/services/node_selection_service.js
+++ b/src/app/services/node_selection_service.js
@@ -5,20 +5,20 @@ const _ = require('underscore');
 var SELECTOR_PARENTS = '+'
 var SELECTOR_CHILDREN = '+'
 var SELECTOR_GLOB = '*'
+var SELECTOR_TYPE = {
+    FQN: 'fqn:',
+    TAG: 'tag:'
+}
 
 angular
 .module('dbt')
 .factory('selectorService', ["$state", function($state) {
 
-    var node_types = [
-        'model',
-    ]
-
     var initial_selector = {
         include: '',
         exclude: '',
         packages: [],
-        node_types: node_types,
+        tags: [],
         depth: 1,
     };
 
@@ -32,17 +32,23 @@ angular
 
         options: {
             packages: [],
-            node_types: node_types,
+            tags: [],
         }
     };
 
     service.init = function(defaults) {
         var all_packages = defaults.packages;
+        var all_tags = defaults.tags;
 
         service.options.packages = all_packages;
         initial_selector.packages = all_packages;
         service.selection.clean.packages = all_packages;
         service.selection.dirty.packages = all_packages;
+
+        service.options.tags = all_tags;
+        initial_selector.tags = all_tags;
+        service.selection.clean.tags = all_tags;
+        service.selection.dirty.tags = all_tags;
     }
 
     service.resetSelection = function(node) {
@@ -87,7 +93,7 @@ angular
     }
 
     service.isDirty = function() {
-        var keys = ['include', 'exclude', 'packages', 'node_types']
+        var keys = ['include', 'exclude', 'packages', 'tags']
         var res = _.isEqual(service.selection.clean, service.selection.dirty);
         return !res
     }
@@ -148,12 +154,22 @@ angular
         }
 
         var node_selector = node_spec.substring(index_start, index_end)
-        var qualified_node_name = node_selector.split('.');
+
+        var selector_type;
+        var selector_val;
+        if (node_selector.startsWith(SELECTOR_TYPE.TAG)) {
+            selector_type = SELECTOR_TYPE.TAG;
+            selector_val = node_selector.replace(selector_type, '');
+        } else {
+            selector_type = SELECTOR_TYPE.FQN;
+            selector_val = node_selector.replace(selector_type, '').split('.');
+        }
 
         return {
             select_parents: select_parents,
             select_children: select_children,
-            qualified_node_name: qualified_node_name,
+            selector_type: selector_type,
+            selector_value: selector_val,
             raw: node_spec
         }
     }
@@ -231,8 +247,24 @@ angular
         return _.uniq(nodes);
     }
 
+    function get_nodes_by_tag(elements, tag) {
+        var nodes = [];
+        _.each(elements, function(node_obj) {
+            var present_tags = node_obj.data.tags;
+            if (_.includes(present_tags, tag)) {
+                nodes.push(node_obj.data);
+            }
+        })
+        return nodes;
+    }
+
     function get_nodes_from_spec(dag, pristine_nodes, hops, selector) {
-        var nodes = get_nodes_by_qualified_name(pristine_nodes, selector.qualified_node_name);
+        var nodes = [];
+        if (selector.selector_type == SELECTOR_TYPE.FQN) {
+            nodes = get_nodes_by_qualified_name(pristine_nodes, selector.selector_value);
+        } else if (selector.selector_type == SELECTOR_TYPE.TAG) {
+            nodes = get_nodes_by_tag(pristine_nodes, selector.selector_value);
+        }
 
         var selected_nodes = [];
         var matched_nodes = [];
@@ -301,9 +333,9 @@ angular
             var node = pristine[node_id];
 
             var matched_package = _.includes(selected_spec.packages, node.data.package_name);
-            var matched_type = _.includes(selected_spec.node_types, node.data.resource_type);
+            var matched_tags = _.intersection(selected_spec.tags, node.data.tags).length > 0;
 
-            if (!matched_package || !matched_type) {
+            if (!matched_package || !matched_tags) {
                 nodes_to_prune.push(node.data.unique_id);
             }
         })


### PR DESCRIPTION
Closes #6 

This PR replaces the `node_type` filter with `tags`, as there isn't generally a need to filter by node types in the graph viz.

I needed to re-implement some more of the dbt graph selection code in JS -- I think we'll need to figure out better ways of doing this if/when graph selection gets more complex.

Relevant tags PR: https://github.com/fishtown-analytics/dbt/pull/1014

Test:
 - [x] model view shows tags for a model, or None
 - [x] DAG view is filterable by tags in a dropdown filter
 - [x] `--models` and `--exclude` accept `tag:` and `fqn:` filter strings
 - [x] dropdown tag filters play nice with fqn/tag selection using `--models` and `--exclude`
