### PR TITLE
fix node selection syntax to match logic in dbt-core

### DIFF
--- a/src/app/services/node_selection_service.js
+++ b/src/app/services/node_selection_service.js
@@ -235,21 +235,18 @@ angular
 
             var ret;
             if (selector_part == SELECTOR_GLOB) {
-                ret = true;
+                return true;
             } else if (is_last && selector_part == _.last(real_node)) {
-                ret = true;
+                return true;
             } else if (real_node.length <= i) {
-                ret = false;
+                return false;
             } else if (real_node[i] == selector_part) {
                 // pass
             } else {
-                ret = false;
-            }
-
-            if (ret !== undefined) {
-                return ret;
+                return false;
             }
         };
+        return true;
     }
 
     function get_nodes_by_qualified_name(elements, qualified_name) {


### PR DESCRIPTION
This PR changes the logic in `is_selected_node` to better match the implementation in dbt-core. I think I initially chose to set the `ret` value then return at the end of the implementation because i was using `_.each()` initially? The logic here now matches that of dbt-core exactly -- if each "selector part" matches the corresponding FQN part, then that node is a match. The `GLOB` selector part was previously required, but now it is optional.

Test it with:
```
staging.* == staging
marts.* == marts
marts.core.* == marts.core
```

closes #36