### PR TITLE
support docs for data tests, view in DAG (optional)

### DIFF
--- a/src/app/components/graph/graph-launcher.html
+++ b/src/app/components/graph/graph-launcher.html
@@ -101,6 +101,35 @@
                                   ng-submit="onUpdateSelector()">
                                 <label class="field">
                                     <div class="dropdown dropup"
+                                         ng-class="{'open': isVisible('resource_types')}"
+                                         data-form-type="resource_types">
+                                        <select
+                                            data-toggle="dropdown"
+                                            class='field-input form-control input-dark'
+                                            ng-click="onSelectClick('resource_types')"
+                                            ng-blur="onSelectBlur('resource_types')">
+                                            <option selected disabled hidden>
+                                                <span>{{ selectionLabel('resource_types') }}</span>
+                                            </option>
+                                        </select>
+                                        <ul
+                                            class="dropdown-menu"
+                                            ng-show="isVisible('resource_types')">
+                                            <li
+                                                class='text-dark'
+                                                ng-repeat="item in selectorService.options.resource_types"
+                                                ng-click="onItemSelect('resource_types', item, $event)">
+                                                {{ resourceTypeTitle(item) }}
+                                                <span ng-show="isSelected('resource_types', item)">
+                                                    <svg class="checked" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.285 2l-11.285 11.567-5.286-5.011-3.714 3.716 9 8.728 15-15.285z"/></svg>
+                                                </span>
+                                            </li>
+                                        </ul>
+                                        <div class="field-label">resources</div>
+                                    </div>
+                                </label>
+                                <label class="field">
+                                    <div class="dropdown dropup"
                                          ng-class="{'open': isVisible('packages')}"
                                          data-form-type="packages">
                                         <select

--- a/src/app/components/graph/graph-launcher.js
+++ b/src/app/components/graph/graph-launcher.js
@@ -27,6 +27,9 @@ angular
                 },
                 packages: {
                     visible: false,
+                },
+                resource_types: {
+                    visible: false,
                 }
             };
 
@@ -96,6 +99,14 @@ angular
                     // blur it
                 } else if (scope.isVisible(form)) {
                     $($event.target).focus();
+                }
+            }
+
+            scope.resourceTypeTitle = function(item) {
+                if (item == 'analysis') {
+                    return 'Analyses';
+                } else {
+                    return item[0].toUpperCase() + item.slice(1) + 's'
                 }
             }
 

--- a/src/app/docs/index.js
+++ b/src/app/docs/index.js
@@ -3,3 +3,4 @@ require('./model');
 require('./source');
 require('./seed');
 require('./snapshot');
+require('./test');

--- a/src/app/docs/test.html
+++ b/src/app/docs/test.html
@@ -1,0 +1,81 @@
+<style>
+/* TODO */
+.section-target {
+    top: -8em;
+}
+
+.noflex {
+    flex: 0 0 160px !important;
+}
+
+.highlight {
+    color: #24292e;
+    background-color: white;
+}
+
+</style>
+
+<div class='app-scroll'>
+    <div class="app-links app-sticky">
+        <div class="app-title">
+            <div class="app-frame app-pad app-flush-bottom">
+                <h1>
+                    <span class="break">{{ model.name }}</span>
+                    <small>test</small>
+                </h1>
+            </div>
+        </div>
+        <div class="app-frame app-pad-h">
+            <ul class="nav nav-tabs">
+                <li ui-sref-active='active'><a ui-sref="dbt.test({'#': 'description'})">Description</a></li>
+                <li ui-sref-active='active'><a ui-sref="dbt.test({'#': 'sql'})">SQL</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="app-details">
+        <div class="app-frame app-pad">
+            <section class="section">
+                <div class="section-target" id="description"></div>
+                <div class="section-content">
+                    <h6>Description</h6>
+                    <div class="panel">
+                        <div class="panel-body">
+                            <div ng-if="model.description" class="model-markdown" marked="model.description"></div>
+                            <div ng-if="!model.description">This {{ model.resource_type }} is not currently documented</div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="section">
+                <div class="section-target" id="sql"></div>
+                <div class="section-content">
+                    <h6>SQL</h6>
+                    <div class="panel">
+                        <div class="panel-body">
+                            <ul class="nav nav-tabs">
+                                <li ng-class="{active: !view_compiled_sql}"><a ng-click="view_compiled_sql=false">Source</a></li>
+                                <li ng-class="{active: view_compiled_sql}"><a ng-click="view_compiled_sql=true">Compiled</a></li>
+                                <li class='nav-pull-right'></li>
+                                <li>
+                                    <a class='unselectable'
+                                       ng-click="copy_to_clipboard(view_compiled_sql ? model.injected_sql : model.raw_sql)">{{ copied ? 'copied' : 'copy to clipboard' }}</a>
+                                </li>
+                            </ul>
+                            <div style="margin-top: 1px" ng-show="!view_compiled_sql">
+                                <pre
+                                    class="source-code highlight sql"
+                                    ng-bind-html="highlighted.source"></pre>
+                            </div>
+                            <div style="margin-top: 1px" ng-show="view_compiled_sql">
+                                <pre
+                                    class="source-code highlight sql"
+                                    ng-bind-html="highlighted.compiled"></pre>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+</div>

--- a/src/app/docs/test.js
+++ b/src/app/docs/test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const angular = require('angular');
+const hljs = require('highlight.js/lib/highlight.js');
+const $ = require("jquery");
+
+hljs.initHighlightingOnLoad();
+hljs.initLineNumbersOnLoad();
+
+require("./styles.css");
+
+const _ = require('underscore');
+
+angular
+.module('dbt')
+.controller('TestCtrl', ['$scope', '$state', 'project', 'code', '$anchorScroll', '$location',
+            function($scope, $state, projectService, codeService, $anchorScroll, $location) {
+
+    $scope.model_uid = $state.params.unique_id;
+    $scope.tab = $state.params.tab;
+    $scope.project = projectService;
+    $scope.codeService = codeService;
+
+    $scope.highlighted = {
+        source: '',
+        compiled: ''
+    }
+
+    $scope.copied = false;
+    $scope.copy_to_clipboard = function(sql) {
+        codeService.copy_to_clipboard(sql)
+        $scope.copied = true;
+        setTimeout(function() {
+            $scope.$apply(function() {
+                $scope.copied = false;
+            })
+        }, 1000);
+    }
+
+    $scope.model = {};
+    projectService.ready(function(project) {
+        $scope.model = project.nodes[$scope.model_uid];
+
+        var default_compiled = '\n-- compiled SQL not found for this model\n';
+        $scope.highlighted.source = codeService.highlightSql($scope.model.raw_sql);
+        $scope.highlighted.compiled = codeService.highlightSql($scope.model.injected_sql || default_compiled);
+
+        $(".source-code").each(function(i, el) {
+            hljs.lineNumbersBlock(el);
+        });
+
+        setTimeout(function() {
+            $anchorScroll();
+        }, 0);
+    })
+}]);

--- a/src/app/index.routes.js
+++ b/src/app/index.routes.js
@@ -13,6 +13,7 @@ const templates = {
     source: require('./docs/source.html'),
     snapshot: require('./docs/snapshot.html'),
     seed: require('./docs/seed.html'),
+    test: require('./docs/test.html'),
 }
 
 angular
@@ -59,6 +60,14 @@ angular
             url: 'snapshot/:unique_id?section&' + graph_params,
             controller: 'SnapshotCtrl',
             templateUrl: templates.snapshot,
+            params: {
+                unique_id: {type: 'string'}
+            },
+        })
+        .state('dbt.test', {
+            url: 'test/:unique_id?section&' + graph_params,
+            controller: 'TestCtrl',
+            templateUrl: templates.test,
             params: {
                 unique_id: {type: 'string'}
             },

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -310,7 +310,9 @@ angular
 
 
         _.each(_.filter(service.manifest.nodes, function(node) {
-                return _.includes(['model', 'seed', 'source', 'snapshot'], node.resource_type);
+            var is_graph_type = _.includes(['model', 'seed', 'source', 'snapshot'], node.resource_type);
+            var is_data_test = node.resource_type == 'test' && _.includes(node.tags, 'data');
+            return is_graph_type || is_data_test;
         }), function(node) {
             var node_obj = {
                 group: "nodes",
@@ -331,9 +333,9 @@ angular
 
                 if (!_.includes(['model', 'source', 'seed', 'snapshot'], parent_node.resource_type)) {
                     return;
-                } else if (child_node.resource_type != 'model' && child_node.resource_type != 'snapshot') {
+                } else if (child_node.resource_type == 'test' && _.includes(child_node.tags, 'schema')) {
                     return;
-                };
+                }
 
                 var unique_id = parent_node.unique_id + "|" + child_node.unique_id;
 

--- a/src/app/services/node_selection_service.js
+++ b/src/app/services/node_selection_service.js
@@ -21,6 +21,12 @@ angular
         exclude: '',
         packages: [],
         tags: [null],
+        resource_types: [
+            'model',
+            'seed',
+            'snapshot',
+            'source'
+        ],
         depth: 1,
     };
 
@@ -35,6 +41,7 @@ angular
         options: {
             packages: [],
             tags: [null],
+            resource_types: ['model', 'seed', 'snapshot', 'source', 'test'],
         }
     };
 
@@ -108,7 +115,7 @@ angular
     }
 
     service.isDirty = function() {
-        var keys = ['include', 'exclude', 'packages', 'tags']
+        var keys = ['include', 'exclude', 'packages', 'tags', 'resource_types']
         var res = _.isEqual(service.selection.clean, service.selection.dirty);
         return !res
     }
@@ -397,8 +404,9 @@ angular
             var matched_package = _.includes(selected_spec.packages, node.data.package_name);
             var matched_tags = _.intersection(selected_spec.tags, node.data.tags).length > 0;
             var matched_untagged = _.includes(selected_spec.tags, null) && (node.data.tags.length == 0);
+            var matched_types = _.includes(selected_spec.resource_types, node.data.resource_type);
 
-            if (!matched_package || (!matched_tags && !matched_untagged)) {
+            if (!matched_package || (!matched_tags && !matched_untagged) || !matched_types) {
                 nodes_to_prune.push(node.data.unique_id);
             }
         })


### PR DESCRIPTION
Fixes https://github.com/fishtown-analytics/dbt/issues/1051
Fixes #67
Fixes (partially) #43

- Adds custom data tests to the docs UI
- Adds a resource type selector to the DAG view

In the future, we should do some work to color these different resource types differently. The more node types we add to the DAG, the more confusing things get!
