### PR TITLE
Exclude null database from relation details

### DIFF
--- a/src/app/components/table_details/table_details.js
+++ b/src/app/components/table_details/table_details.js
@@ -76,13 +76,20 @@ angular
                 var is_ephemeral = !model.metadata;
                 var metadata = model.metadata || {};
 
+                var database;
+                if (model.database == null) { 
+                    database = '' 
+                } else {
+                    database = model.database + '.'
+                }
+
                 var relation;
                 if (is_ephemeral) {
                     relation = undefined;
                 } else if (model.resource_type == 'source') {
-                    relation = model.database + "." + model.schema + "." + model.identifier;
+                    relation = database + model.schema + "." + model.identifier;
                 } else {
-                    relation = model.database + "." + model.schema + "." + model.alias;
+                    relation = database + model.schema + "." + model.alias;
                 }
 
                 var stats = [

--- a/src/app/components/table_details/table_details.js
+++ b/src/app/components/table_details/table_details.js
@@ -77,7 +77,7 @@ angular
                 var metadata = model.metadata || {};
 
                 var database;
-                if (model.database == null) { 
+                if (!model.database) { 
                     database = '' 
                 } else {
                     database = model.database + '.'


### PR DESCRIPTION
* Resolves #94
* Complements https://github.com/fishtown-analytics/dbt-spark/pull/92

<img width="600" alt="Screen Shot 2020-05-29 at 5 58 46 PM" src="https://user-images.githubusercontent.com/13897643/83309112-6e127c80-a1d6-11ea-851f-515f2db7bc7e.png">

I think the better answer—letting the adapter weigh in on its include policy—would require passing the full relation namespace to `manifest.json`. (It could be there already, and I just missed it.)