### PR TITLE
Update bundler instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Then, install yarn and webpack.
 npm install -g yarn webpack webpack-cli
 ```
 
-You'll also need to install jekyll if you don't already have it:
+You'll also need to install bundler if you don't already have it:
 ```bash
 gem install bundler
 bundle install

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ npm install -g yarn webpack webpack-cli
 
 You'll also need to install jekyll if you don't already have it:
 ```bash
-gem install bundler jekyll
+gem install bundler
+bundle install
 ```
 
 ### Build / Run
@@ -49,7 +50,7 @@ To build the css files required for webpack:
 
 ```bash
 cd styles
-jekyll build
+bundle exec jekyll build
 cd -
 ```
 


### PR DESCRIPTION
Installing jeckyll with bundle install ensures that we get the version that is compatible with this code. See issue #78 