### PR TITLE
Add search relevance criteria to DBT search function

### DIFF
--- a/src/app/components/search/search.html
+++ b/src/app/components/search/search.html
@@ -22,7 +22,7 @@
     <div class="app-details">
         <div class="app-frame app-pad">
             <div class="results">
-                <div ng-repeat="result in results | filter:limit_search | orderBy:'-model.name':true track by result.model.unique_id"
+                <div ng-repeat="result in results | filter:limit_search | orderBy:'overallWeight':true track by result.model.unique_id"
                      data-ui-state="getState(result.model)" data-ui-state-params="{unique_id: result.model.unique_id}"
                      ng-click="onSelect()"
                      class="result search-result a">

--- a/src/app/main/index.js
+++ b/src/app/main/index.js
@@ -148,6 +148,8 @@ angular
     });
 
     function assignSearchRelevance(results){
+        if($scope.search.query === "")
+            return results;
         let criteriaArr = {
             "name": 10,
             "tags": 5,

--- a/src/app/main/index.js
+++ b/src/app/main/index.js
@@ -142,6 +142,11 @@ angular
         }
     });
 
+
+    $scope.$watch('search.query', function(q) {
+        $scope.search.results = assignSearchRelevance(projectService.search(q));
+    });
+
     function assignSearchRelevance(results){
         let criteriaArr = {
             "name": 10,
@@ -185,10 +190,6 @@ angular
         }); 
         return results;
     }
-
-    $scope.$watch('search.query', function(q) {
-        $scope.search.results = assignSearchRelevance(projectService.search(q));
-    });
 
 
     /*

--- a/src/app/main/index.js
+++ b/src/app/main/index.js
@@ -150,6 +150,7 @@ angular
     function assignSearchRelevance(results){
         let criteriaArr = {
             "name": 10,
+            "tags": 5,
             "description": 3,
             "raw_sql": 2,
             "columns": 1
@@ -161,12 +162,24 @@ angular
                     let count = 0;
                     let body = result.model[criteria];
                     let query = ($scope.search.query).toLowerCase();
-                    if(typeof(body) === "object"){
+                    if(criteria === "columns"){
                         _.each(body, function(column){
                             let columnName = column.name.toLowerCase();
                             let index = 0;
                             while(index != -1){
                                 index = columnName.indexOf(query, index);
+                                if (index != -1) {
+                                    count++; index++;
+                                }
+                            }
+                        });
+                    }
+                    else if(criteria === "tags"){
+                        _.each(body, function(tag){
+                            let tagName = tag.toLowerCase();
+                            let index = 0;
+                            while(index != -1){
+                                index = tagName.indexOf(query, index);
                                 if (index != -1) {
                                     count++; index++;
                                 }
@@ -183,7 +196,6 @@ angular
                             }
                         }
                     }
-                    
                     result.overallWeight += (count * criteriaArr[criteria]);
                 }
             });

--- a/src/app/main/index.js
+++ b/src/app/main/index.js
@@ -142,8 +142,52 @@ angular
         }
     });
 
+    function assignSearchRelevance(results){
+        let criteriaArr = {
+            "name": 10,
+            "description": 3,
+            "raw_sql": 2,
+            "columns": 1
+        };
+        _.each(results, function(result){
+            result.overallWeight = 0;
+            _.each(Object.keys(criteriaArr), function(criteria){
+                if(result.model[criteria] != undefined){
+                    let count = 0;
+                    let body = result.model[criteria];
+                    let query = ($scope.search.query).toLowerCase();
+                    if(typeof(body) === "object"){
+                        _.each(body, function(column){
+                            let columnName = column.name.toLowerCase();
+                            let index = 0;
+                            while(index != -1){
+                                index = columnName.indexOf(query, index);
+                                if (index != -1) {
+                                    count++; index++;
+                                }
+                            }
+                        });
+                    }
+                    else{
+                        body = body.toLowerCase();
+                        let index = 0;
+                        while(index != -1){
+                            index = body.indexOf(query, index);
+                            if(index != -1){
+                                count++; index++;
+                            }
+                        }
+                    }
+                    
+                    result.overallWeight += (count * criteriaArr[criteria]);
+                }
+            });
+        }); 
+        return results;
+    }
+
     $scope.$watch('search.query', function(q) {
-        $scope.search.results = projectService.search(q);
+        $scope.search.results = assignSearchRelevance(projectService.search(q));
     });
 
 


### PR DESCRIPTION
### Problem
In the DBT search function, search results are sorted in alphabetical order by the model name. This is not optimal for a search function, and can cause some difficulty for visibility of relevant search results for the user.

### Solution
To solve this issue, this PR adds a "weight" criteria to each search result, which is an indication of how relevant it is to the user (the larger the number, the more relevant). To specify, weight will be added to a search result if the search query matches the name, tags, description, SQL code, or columns, whose weights are biggest to smallest in that respective order. Based on this, the order of the search results is sorted from the greatest to least "weight," and therefore allows for easier visibility of more relevant search results for the user.

### Other Information
- Resolves #112
- @Matt343 is also a collaborator on this PR