### PR TITLE
Fix issues with anonymous event tracking on the docs site

### DIFF
--- a/src/app/main/index.js
+++ b/src/app/main/index.js
@@ -242,8 +242,7 @@ angular
         var meta = (project.metadata || {})
         trackingService.init({
             track: meta.send_anonymous_usage_stats,
-            project_id: meta.project_id,
-            user_id: meta.user_id,
+            project_id: meta.project_id
         });
 
     });


### PR DESCRIPTION
Fixes #111 

This PR:
- Does a simpler & better job of completely fuzzing non-cloud hosted docs urls
- Does not track custom user_id in pageview events
- Differentiates between cloud and non-cloud docs pageviews