### PR TITLE
Added a button to toggle package names in the table graph

### DIFF
--- a/src/app/components/graph/graph-launcher.html
+++ b/src/app/components/graph/graph-launcher.html
@@ -201,6 +201,14 @@
                                            placeholder="..." />
                                     <div class="field-label">--exclude</div>
                                 </label>
+                                <label class="field" style="flex: 4 0 80px">
+                                    <input type="submit"
+                                           class="field-input form-control input-dark"
+                                           value="{{toggleButtonTextHorizontal}}"
+                                           ng-click = "togglePackageNamesHorizontal()" 
+                                           style = "text-align:center;"/>
+                                    <div class="field-label text-center" style="width: 100%"></div>
+                                </label>
                                 <label class="field" style="flex: 0 0 80px">
                                     <input type="submit"
                                            id="submit-graph-selection"
@@ -221,12 +229,23 @@
                     </div>
                     <!--<div class="launcher-spacer"></div>-->
                     <div class="launcher-actions" ng-show="graphService.orientation == 'sidebar'">
-                        <button type="button"
-                            ng-click="closeGraph()"
-                            class="btn btn-text btn-lg btn-icon btn-shadow"
-                            data-toggle="tooltip"
-                            title="Close Graph"><svg class="icn icn-md"><use xlink:href="#icn-close"></use></svg>
-                        </button>
+                        <div style = "text-align:center;">
+                            <label class="field" style="flex: 4 0 80px; float:left">
+                                <input type="submit"
+                                       class="field-input form-control input-dark"
+                                       value="{{toggleButtonTextVertical}}"
+                                       ng-click = "togglePackageNamesVertical(); onUpdateSelectorVertical()" 
+                                       style = "text-align:center;"/>
+                                <div class="field-label text-center" style="width: 100%"></div>
+                            </label>
+                            <button type="button"
+                                ng-click="closeGraph()"
+                                class="btn btn-text btn-lg btn-icon btn-shadow"
+                                data-toggle="tooltip"
+                                title="Close Graph"
+                                style="float: right"><svg class="icn icn-md"><use xlink:href="#icn-close"></use></svg>
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/app/components/graph/graph-launcher.js
+++ b/src/app/components/graph/graph-launcher.js
@@ -33,6 +33,18 @@ angular
                 }
             };
 
+            scope.toggleButtonTextHorizontal = "Show Package Name";
+            scope.toggleButtonTextVertical = "Show Package Name";
+
+            scope.togglePackageNamesHorizontal = function(){
+                scope.graphService.toggle_package_name_horizontal = !scope.graphService.toggle_package_name_horizontal;
+                scope.toggleButtonTextHorizontal = (scope.toggleButtonTextHorizontal === "Show Package Name") ? "Hide Package Name": "Show Package Name";
+            }
+            scope.togglePackageNamesVertical = function(){
+                scope.graphService.toggle_package_name_vertical = !scope.graphService.toggle_package_name_vertical;
+                scope.toggleButtonTextVertical = (scope.toggleButtonTextVertical === "Show Package Name") ? "Hide Package Name": "Show Package Name";
+            }
+
             scope.onWindowClick = function(e) {
                 var target = $(e.target);
 
@@ -128,6 +140,13 @@ angular
             scope.onUpdateSelector = function() {
                 var selector = selectorService.updateSelection();
                 var nodes = graph.updateGraph(selector)
+
+                trackingService.track_graph_interaction('update-graph', nodes.length);
+            }
+
+            scope.onUpdateSelectorVertical = function() {
+                var selector = selectorService.updateSelection();
+                var nodes = graph.updateGraphVertical(selector)
 
                 trackingService.track_graph_interaction('update-graph', nodes.length);
             }

--- a/src/app/services/graph.service.js
+++ b/src/app/services/graph.service.js
@@ -65,6 +65,8 @@ angular
         loading: true,
         loaded: $q.defer(),
 
+        toggle_package_name_horizontal: false,
+        toggle_package_name_vertical: false,
         graph_element: null,
         orientation: 'sidebar',
         expanded: false,
@@ -141,7 +143,7 @@ angular
                         'width': '5px',
                         'height': '5px',
                         'padding': '5px',
-                        'content': 'data(label)',
+                        'content': 'data(package_and_label_vertical)',
                         'font-weight': 300,
                         'text-valign': 'center',
                         'text-halign': 'right',
@@ -157,7 +159,7 @@ angular
                         'width': 'label',
                         'height': 'label',
                         'padding': '12px',
-                        'content': 'data(label)',
+                        'content': 'data(package_and_label_horizontal)',
                         'font-weight': 300,
                         'font-family': '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Helvetica, Arial, sans-serif',
                         'text-valign': 'center',
@@ -450,6 +452,27 @@ angular
     service.updateGraph = function(selected_spec) {
         service.orientation = 'fullscreen'
         service.expanded = true;
+        if(service.toggle_package_name_horizontal){
+            _.each(service.graph.pristine.nodes, function (node){
+                node.data.package_and_label_horizontal = node.data.package_name + "." + node.data.label;
+            });
+        }
+        else{
+            _.each(service.graph.pristine.nodes, function (node){
+                node.data.package_and_label_horizontal = node.data.label;
+            });
+        }
+
+        if(service.toggle_package_name_vertical){
+            _.each(service.graph.pristine.nodes, function (node){
+                node.data.package_and_label_vertical = node.data.package_name + "." + node.data.label;
+            });
+        }
+        else{
+            _.each(service.graph.pristine.nodes, function (node){
+                node.data.package_and_label_vertical = node.data.label;
+            });
+        }
 
         var nodes = updateGraphWithSelector(selected_spec, 'horizontal', false);
         service.graph.layout = layouts.left_right;
@@ -458,6 +481,40 @@ angular
         // update url with selection
         locationService.setState(selected_spec);
 
+        return nodes;
+    }
+
+    service.updateGraphVertical = function(selected_spec) {
+        service.orientation = 'sidebar';
+        service.expanded = false;
+        if(service.toggle_package_name_horizontal){
+            _.each(service.graph.pristine.nodes, function (node){
+                node.data.package_and_label_horizontal = node.data.package_name + "." + node.data.label;
+            });
+        }
+        else{
+            _.each(service.graph.pristine.nodes, function (node){
+                node.data.package_and_label_horizontal = node.data.label;
+            });
+        }
+
+        if(service.toggle_package_name_vertical){
+            _.each(service.graph.pristine.nodes, function (node){
+                node.data.package_and_label_vertical = node.data.package_name + "." + node.data.label;
+            });
+        }
+        else{
+            _.each(service.graph.pristine.nodes, function (node){
+                node.data.package_and_label_vertical = node.data.label;
+            });
+        }
+
+        var nodes = updateGraphWithSelector(selected_spec, 'vertical', false);
+        service.graph.layout = layouts.left_right;
+        service.graph.options = graph_options.vertical;
+
+        // update url with selection
+        locationService.setState(selected_spec);
         return nodes;
     }
 


### PR DESCRIPTION
### Problem
To view the package names of each respective node on the table graph, one must right click the node and view the documentation, which can be annoying to simply just view the package name of the selected node.

### Solution
To make this process more convenient, this PR adds a button to the table graph that can toggle package names as an extension of the node names in the table graph.

### Other Information
- Resolves #122 
- @Matt343 is also a collaborator on this PR