### PR TITLE
Add changelog, github templates

### DIFF
--- a/.github/issue_template/bug_report.md
+++ b/.github/issue_template/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Report a bug or an issue you've found with dbt-docs
+title: ''
+labels: bug, triage
+assignees: ''
+
+---
+
+### Describe the bug
+A clear and concise description of what the bug is. What command did you run? What happened?
+
+### Steps To Reproduce
+In as much detail as possible, please provide steps to reproduce the issue. Sample data that triggers the issue, example model code, etc is all very helpful here.
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Screenshots and log output
+If applicable, add screenshots or log output to help explain your problem.
+
+**The output of `dbt --version`:**
+```
+<output goes here>
+```
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/issue_template/enhancement.md
+++ b/.github/issue_template/enhancement.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for dbt-docs
+title: ''
+labels: enhancement, triage
+assignees: ''
+
+---
+
+### Describe the feature
+A clear and concise description of what you want to happen.
+
+### Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context
+Is this feature database-specific? Which database(s) is/are relevant? Please include any other relevant context here.
+
+### Who will this benefit?
+What kind of use case will this feature be useful for? Please be specific and provide examples, this will help us prioritize properly.
+
+### Are you interested in contributing this feature?
+Let us know if you want to write some code, and how we can help.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+resolves #
+
+<!---
+  Include the number of the issue addressed by this PR above if applicable.
+  PRs for code changes without an associated issue *will not be merged*.
+  See CONTRIBUTING.md for more information.
+
+  Example:
+    resolves #1234
+-->
+
+
+### Description
+
+<!--- Describe the Pull Request here -->
+
+
+### Checklist
+ - [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
+ - [ ] I have generated docs locally, and this change appears to resolve the stated issue
+ - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
+ 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## dbt 0.18.0 (Release TBD)
+
+## dbt 0.18.0rc1 (August 19, 2020)
+
+- Add "Referenced By" and "Depends On" sections for each node ([docs#106](https://github.com/fishtown-analytics/dbt-docs/pull/106))
+- Add Name, Description, Column, SQL, Tags filters to site search ([docs#108](https://github.com/fishtown-analytics/dbt-docs/pull/108))
+- Add relevance criteria to site search ([docs#113](https://github.com/fishtown-analytics/dbt-docs/pull/113))
+- Support new selector methods, intersection, and arbitrary parent/child depth in DAG selection syntax ([docs#118](https://github.com/fishtown-analytics/dbt-docs/pull/118))
+- Revise anonymous event tracking: simpler URL fuzzing; differentiate between Cloud-hosted and non-Cloud docs ([docs#121](https://github.com/fishtown-analytics/dbt-docs/pull/121))
+
+Contributors:
+- [@stephen8chang](https://github.com/stephen8chang) ([docs#106](https://github.com/fishtown-analytics/dbt-docs/pull/106), [docs#108](https://github.com/fishtown-analytics/dbt-docs/pull/108), [docs#113](https://github.com/fishtown-analytics/dbt-docs/pull/113))


### PR DESCRIPTION
### Housekeeping

* Add changelog, with notes from 0.18.0rc1
* Add PR templates
    * Is this is overkill?
    * Should we enable cla-bot for this repo?
* I plan to cut a release in this repo with the same semantic version as the corresponding dbt release, i.e. before opening PRs such as https://github.com/fishtown-analytics/dbt/pull/2715. I want to release 0.18.0-rc1 after merging this PR, and before merging any PRs currently open.