### PR TITLE
Fix issue where sources nodes with tags were excluded from graph viz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## dbt 0.19.0 (Release TBD)
+- Fixed issue where sources with tags were not showing up in graph viz. ([docs#93](https://github.com/fishtown-analytics/dbt-docs/issues/93))
+
+Contributors:
+- [@jplynch77](https://github.com/jplynch77) ([docs#139](https://github.com/fishtown-analytics/dbt-docs/pull/139))
 
 ## dbt 0.18.1 (Unreleased)
 - Add Exposure nodes ([docs#135](https://github.com/fishtown-analytics/dbt-docs/issues/135), [docs#136](https://github.com/fishtown-analytics/dbt-docs/pull/136), [docs#137](https://github.com/fishtown-analytics/dbt-docs/pull/137))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## dbt 0.19.0 (Release TBD)
-- Fixed issue where sources with tags were not showing up in graph viz. ([docs#93](https://github.com/fishtown-analytics/dbt-docs/issues/93))
+- Fixed issue where sources with tags were not showing up in graph viz ([docs#93](https://github.com/fishtown-analytics/dbt-docs/issues/93))
 
 Contributors:
 - [@jplynch77](https://github.com/jplynch77) ([docs#139](https://github.com/fishtown-analytics/dbt-docs/pull/139))

--- a/src/app/main/index.js
+++ b/src/app/main/index.js
@@ -222,7 +222,7 @@ angular
         var packages = _.unique(_.pluck(_.values(project.nodes), 'package_name'))
         var all_tags = [null];
         _.each(project.nodes, function(node) {
-            if (node.resource_type == 'model') {
+            if (node.resource_type == 'model' || node.resource_type == 'source') {
                 var tags = node.tags;
                 all_tags = _.union(all_tags, tags);
             };

--- a/src/app/main/index.js
+++ b/src/app/main/index.js
@@ -222,7 +222,7 @@ angular
         var packages = _.unique(_.pluck(_.values(project.nodes), 'package_name'))
         var all_tags = [null];
         _.each(project.nodes, function(node) {
-            if (node.resource_type == 'model' || node.resource_type == 'source') {
+            if (node.resource_type != 'test') {
                 var tags = node.tags;
                 all_tags = _.union(all_tags, tags);
             };


### PR DESCRIPTION
resolves #93 

### Description

This resolves an issue where source nodes with tags were not showing up in the graph visualization. The root problem seems to be that tags from sources are not added to `all_tags` in `main/index.js`. This causes `selectNodes()` in `selector_methods.js` to exclude sources with tags. Specifically, a source node with a tag ends up hitting the `(!matched_tags && !matched_untagged)` condition in
```
        if (!matched_package || (!matched_tags && !matched_untagged) || !matched_types) {
            nodes_to_prune.push(node.data.unique_id);
        }
```

This change also makes tags defined only on sources available in tags drop-down in the graph viz. 

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have generated docs locally, and this change appears to resolve the stated issue
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 