### PR TITLE
refactor: render relationship test on defining model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## dbt 0.19.0 (Release TBD)
+## dbt 0.19.2 (Release TBD)
+- Reversed the rendering direction of relationship tests so that the test renders in the model it is defined in ([docs#181](https://github.com/fishtown-analytics/dbt-docs/issues/181), [docs#183](https://github.com/fishtown-analytics/dbt-docs/pull/183))
+
+Contributors:
+- [@mascah](https://github.com/mascah) ([docs#181](https://github.com/fishtown-analytics/dbt-docs/issues/181), [docs#183](https://github.com/fishtown-analytics/dbt-docs/pull/183))
+
+## dbt 0.19.0 (January 27, 2021)
 - Fixed issue where data tests with tags were not showing up in graph viz ([docs#147](https://github.com/fishtown-analytics/dbt-docs/issues/147), [docs#156](https://github.com/fishtown-analytics/dbt-docs/pull/156))
 - Clean up development dependencies and docs, fix package installation issue ([docs#164](https://github.com/fishtown-analytics/dbt-docs/issues/164), [docs#165](https://github.com/fishtown-analytics/dbt-docs/pull/165))
 

--- a/src/app/services/project_service.js
+++ b/src/app/services/project_service.js
@@ -170,7 +170,7 @@ angular
                     test_info.short = 'U';
                     test_info.label = 'Unique';
                 } else if (test.test_metadata.name == 'relationships') {
-                    var rel_model_name = test.refs[1];
+                    var rel_model_name = test.refs[0];
                     var rel_model = model_names[rel_model_name];
                     if (rel_model && test.test_metadata.kwargs.field) {
                         // FKs get extra fields
@@ -197,7 +197,11 @@ angular
                 var depends_on = test.depends_on.nodes;
                 var test_column = test.column_name || test.test_metadata.kwargs.column_name || test.test_metadata.kwargs.arg;
                 if (depends_on.length && test_column) {
-                    var model = depends_on[0];
+                    if (test.test_metadata.name == 'relationships') {
+                        var model = depends_on[1];
+                    } else {
+                        var model = depends_on[0]
+                    }
                     var node = project.nodes[model];
                     var column = _.find(node.columns, function(col, col_name) {
                         return col_name.toLowerCase() == test_column.toLowerCase();
@@ -573,7 +577,7 @@ angular
         var databases = {};
         var tree_nodes = _.filter(nodes, function(node) {
             var show = _.get(node, ['docs', 'show'], true);
-            if (!show) { 
+            if (!show) {
                 return false;
             } else if (_.indexOf(['source', 'snapshot', 'seed'], node.resource_type) != -1) {
                 return true;


### PR DESCRIPTION
resolves #181 

### Description

<!--- Describe the Pull Request here -->

Currently a relationship test is rendered on the model that the test points "to".
This change reverses the direction so that the relationship test renders on the model
that the test is defined in, or the "from" model pointing to the parent model.

schema.yml

```
version: 2

models:
    - name: my_first_dbt_model
      description: "A starter dbt model"
      columns:
          - name: id
            description: "The primary key for this table"
            tests:
                - unique
                - not_null

    - name: my_second_dbt_model
      description: "A starter dbt model"
      columns:
          - name: id
            description: "The primary key for this table"
            tests:
                - unique
                - not_null
                - relationships:
                    to: ref('my_first_dbt_model')
                    field: id
```


<img width="1494" alt="Screen Shot 2021-04-01 at 7 50 14 PM" src="https://user-images.githubusercontent.com/6239162/113372630-5f30b500-9326-11eb-8b44-b5885b2aa754.png">


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have generated docs locally, and this change appears to resolve the stated issue
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 