### PR TITLE
Match models whose name contains dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## dbt 0.19.2 (Release TBD)
+## dbt 0.20.0 (Release TBD)
 - Reversed the rendering direction of relationship tests so that the test renders in the model it is defined in ([docs#181](https://github.com/fishtown-analytics/dbt-docs/issues/181), [docs#183](https://github.com/fishtown-analytics/dbt-docs/pull/183))
 - Support dots in model names: display them in the graphs ([docs#184](https://github.com/fishtown-analytics/dbt-docs/issues/184))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## dbt 0.19.2 (Release TBD)
 - Reversed the rendering direction of relationship tests so that the test renders in the model it is defined in ([docs#181](https://github.com/fishtown-analytics/dbt-docs/issues/181), [docs#183](https://github.com/fishtown-analytics/dbt-docs/pull/183))
+- Support dots in model names: display them in the graphs ([docs#184](https://github.com/fishtown-analytics/dbt-docs/issues/184))
 
 Contributors:
 - [@mascah](https://github.com/mascah) ([docs#181](https://github.com/fishtown-analytics/dbt-docs/issues/181), [docs#183](https://github.com/fishtown-analytics/dbt-docs/pull/183))
+- [@monti-python](https://github.com/monti-python) ([docs#184](https://github.com/fishtown-analytics/dbt-docs/issues/184))
 
 ## dbt 0.19.0 (January 27, 2021)
 - Fixed issue where data tests with tags were not showing up in graph viz ([docs#147](https://github.com/fishtown-analytics/dbt-docs/issues/147), [docs#156](https://github.com/fishtown-analytics/dbt-docs/pull/156))

--- a/src/app/services/selector_matcher.js
+++ b/src/app/services/selector_matcher.js
@@ -81,10 +81,6 @@ function getNodesByFQN(elements, qualified_name) {
          */
         var unscoped_flat_fqn = _.rest(flat_fqn);
 
-        console.log(`SELECTOR_FQN: ${selector_fqn} !!!`)
-        console.log(`FQN: ${fqn} !!!`)
-        console.log(`UNESCOPED_FQN: ${unscoped_flat_fqn} !!!`)
-
         // if qualified_name matches exactly model name (fqn's leaf), this is a match
         if (qualified_name === _.last(fqn)) {
             nodes.push(node);

--- a/src/app/services/selector_matcher.test.js
+++ b/src/app/services/selector_matcher.test.js
@@ -99,7 +99,7 @@ test("Test FQN Matching glob", () => {
     expect(
         matcher.isFQNMatch(
             ['my_package', 'dir', 'model'],
-            ['my_package', '*']
+            'my_package.*'
         )
     ).toStrictEqual(true)
 })
@@ -108,7 +108,16 @@ test("Test FQN Matching all parts", () => {
     expect(
         matcher.isFQNMatch(
             ['my_package', 'dir', 'model'],
-            ['my_package', 'dir', 'model']
+            'my_package.dir.model'
+        )
+    ).toStrictEqual(true)
+})
+
+test("Test FQN Matching all parts with dots", () => {
+    expect(
+        matcher.isFQNMatch(
+            ['my_package', 'dir', 'ns1.ns2.model'],
+            'my_package.dir.ns1.ns2.model'
         )
     ).toStrictEqual(true)
 })
@@ -117,7 +126,7 @@ test("Test FQN Matching bare package", () => {
     expect(
         matcher.isFQNMatch(
             ['my_package', 'dir', 'model'],
-            ['my_package']
+            'my_package'
         )
     ).toStrictEqual(true)
 })
@@ -126,7 +135,7 @@ test("Test FQN Matching bare path", () => {
     expect(
         matcher.isFQNMatch(
             ['my_package', 'dir', 'model'],
-            ['my_package', 'dir']
+            'my_package.dir'
         )
     ).toStrictEqual(true)
 })
@@ -135,7 +144,7 @@ test("Test FQN Matching bare path glob", () => {
     expect(
         matcher.isFQNMatch(
             ['my_package', 'dir', 'model'],
-            ['my_package', 'dir', '*']
+            'my_package.dir.*'
         )
     ).toStrictEqual(true)
 })
@@ -144,7 +153,7 @@ test("Test FQN Matching glob all", () => {
     expect(
         matcher.isFQNMatch(
             ['my_package', 'dir', 'model'],
-            ['*']
+            '*'
         )
     ).toStrictEqual(true)
 })
@@ -153,7 +162,16 @@ test("Test FQN Matching direct model name", () => {
     expect(
         matcher.isFQNMatch(
             ['my_package', 'dir', 'model'],
-            ['model']
+            'model'
+        )
+    ).toStrictEqual(true)
+})
+
+test("Test FQN Matching direct model name with dots", () => {
+    expect(
+        matcher.isFQNMatch(
+            ['my_package', 'dir', 'ns1.ns2.model'],
+            'ns1.ns2.model'
         )
     ).toStrictEqual(true)
 })
@@ -162,7 +180,7 @@ test("Test FQN Matching non match package", () => {
     expect(
         matcher.isFQNMatch(
             ['my_package', 'dir', 'model'],
-            ['other_package']
+            'other_package'
         )
     ).toStrictEqual(false)
 })
@@ -171,7 +189,7 @@ test("Test FQN Matching non match path", () => {
     expect(
         matcher.isFQNMatch(
             ['my_package', 'dir', 'model'],
-            ['my_package', 'other_dir']
+            'my_package.other_dir'
         )
     ).toStrictEqual(false)
 })


### PR DESCRIPTION
resolves #184

### Description

In our dbt project we are managing multiple schemas. We are namespacing the models with the standard SQL syntax `<schema>.<relation>.sql` and following [this approach](https://discourse.getdbt.com/t/extracting-schema-and-model-names-from-the-filename/575). It works quite well for the most part, however models with dots don't show up in the graphs on the generated docs

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have generated docs locally, and this change appears to resolve the stated issue
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 