### PR TITLE
feature/render-meta-tags-for-sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## dbt 0.20.0 (Release TBD)
 - Reversed the rendering direction of relationship tests so that the test renders in the model it is defined in ([docs#181](https://github.com/fishtown-analytics/dbt-docs/issues/181), [docs#183](https://github.com/fishtown-analytics/dbt-docs/pull/183))
 - Support dots in model names: display them in the graphs ([docs#184](https://github.com/fishtown-analytics/dbt-docs/issues/184))
+- Render meta tags for sources ([docs#192](https://github.com/fishtown-analytics/dbt-docs/issues/192))
 
 Contributors:
 - [@mascah](https://github.com/mascah) ([docs#181](https://github.com/fishtown-analytics/dbt-docs/issues/181), [docs#183](https://github.com/fishtown-analytics/dbt-docs/pull/183))
 - [@monti-python](https://github.com/monti-python) ([docs#184](https://github.com/fishtown-analytics/dbt-docs/issues/184))
+- [@diegodewilde](https://github.com/diegodewilde) ([docs#192](https://github.com/fishtown-analytics/dbt-docs/issues/192))
 
 ## dbt 0.19.0 (January 27, 2021)
 - Fixed issue where data tests with tags were not showing up in graph viz ([docs#147](https://github.com/fishtown-analytics/dbt-docs/issues/147), [docs#156](https://github.com/fishtown-analytics/dbt-docs/pull/156))

--- a/src/app/components/table_details/table_details.js
+++ b/src/app/components/table_details/table_details.js
@@ -148,8 +148,9 @@ angular
                 var get_type = _.property(['metadata', 'type'])
                 var rel_type = get_type(nv);
 
-                scope.meta = nv.meta || null;
-
+                var sources_meta = nv.hasOwnProperty('sources') ? nv.sources[0] != undefined ? nv.sources[0].source_meta : null : null;
+                scope.meta = nv.meta || sources_meta;
+                
                 scope.details = getBaseStats(nv);
                 scope.extended = getExtendedStats(nv.stats);
 


### PR DESCRIPTION
resolves #192 

### Description

This PR will adds the functionality to render `meta` tags from sources in the .yml file in dbt docs.
 