### PR TITLE
Remove tag exclusion from exposures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 ## dbt 0.20.0 (Release TBD)
+
+Contributors:
+- [@stkbailey](https://github.com/stkbailey) ([docs#194](https://github.com/fishtown-analytics/dbt-docs/issues/194))
+
+
+## dbt 0.20.0rc1 (June 4, 2021)
 - Reversed the rendering direction of relationship tests so that the test renders in the model it is defined in ([docs#181](https://github.com/fishtown-analytics/dbt-docs/issues/181), [docs#183](https://github.com/fishtown-analytics/dbt-docs/pull/183))
 - Support dots in model names: display them in the graphs ([docs#184](https://github.com/fishtown-analytics/dbt-docs/issues/184))
+- Render meta tags for sources ([docs#192](https://github.com/fishtown-analytics/dbt-docs/issues/192))
 
 Contributors:
 - [@mascah](https://github.com/mascah) ([docs#181](https://github.com/fishtown-analytics/dbt-docs/issues/181), [docs#183](https://github.com/fishtown-analytics/dbt-docs/pull/183))
 - [@monti-python](https://github.com/monti-python) ([docs#184](https://github.com/fishtown-analytics/dbt-docs/issues/184))
-- [@stkbailey](https://github.com/stkbailey) ([docs#194](https://github.com/fishtown-analytics/dbt-docs/issues/194))
+- [@diegodewilde](https://github.com/diegodewilde) ([docs#192](https://github.com/fishtown-analytics/dbt-docs/issues/192))
 
 ## dbt 0.19.0 (January 27, 2021)
 - Fixed issue where data tests with tags were not showing up in graph viz ([docs#147](https://github.com/fishtown-analytics/dbt-docs/issues/147), [docs#156](https://github.com/fishtown-analytics/dbt-docs/pull/156))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## dbt 0.20.0 (Release TBD)
 
+
 Contributors:
 - [@stkbailey](https://github.com/stkbailey) ([docs#194](https://github.com/fishtown-analytics/dbt-docs/issues/194))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Contributors:
 - [@mascah](https://github.com/mascah) ([docs#181](https://github.com/fishtown-analytics/dbt-docs/issues/181), [docs#183](https://github.com/fishtown-analytics/dbt-docs/pull/183))
 - [@monti-python](https://github.com/monti-python) ([docs#184](https://github.com/fishtown-analytics/dbt-docs/issues/184))
+- [@stkbailey](https://github.com/stkbailey) ([docs#194](https://github.com/fishtown-analytics/dbt-docs/issues/194))
 
 ## dbt 0.19.0 (January 27, 2021)
 - Fixed issue where data tests with tags were not showing up in graph viz ([docs#147](https://github.com/fishtown-analytics/dbt-docs/issues/147), [docs#156](https://github.com/fishtown-analytics/dbt-docs/pull/156))

--- a/src/app/components/table_details/table_details.js
+++ b/src/app/components/table_details/table_details.js
@@ -148,8 +148,9 @@ angular
                 var get_type = _.property(['metadata', 'type'])
                 var rel_type = get_type(nv);
 
-                scope.meta = nv.meta || null;
-
+                var sources_meta = nv.hasOwnProperty('sources') ? nv.sources[0] != undefined ? nv.sources[0].source_meta : null : null;
+                scope.meta = nv.meta || sources_meta;
+                
                 scope.details = getBaseStats(nv);
                 scope.extended = getExtendedStats(nv.stats);
 

--- a/src/app/docs/exposure.html
+++ b/src/app/docs/exposure.html
@@ -46,7 +46,7 @@
 
             <section class="section">
                 <div class="section-target" id="details"></div>
-                <table-details model="exposure" extras="extra_table_fields" exclude="['tags']" />
+                <table-details model="exposure" extras="extra_table_fields" />
             </section>
 
             <section class="section">


### PR DESCRIPTION
resolves #194 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->


### Description

This PR removes the exclusion of tags from the exposure docs. This is now allowed due to a PR to dbt enabling tags and meta on exposures. fishtown-analytics/dbt#3405

Example result is below (jaffle_shop):

```
exposures:
  - name: user_exposure
    type: dashboard
    depends_on:
      - ref('stg_customers')
    owner:
      email: nope@example.com
    meta:
      foo: bar
      fun: [times]
    tags:
    - funny
    - silly
```

![image](https://user-images.githubusercontent.com/7850417/121025596-510e7300-c773-11eb-9564-dcd282c39b38.png)



### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have generated docs locally, and this change appears to resolve the stated issue
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 